### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node-fetch": "^3.3.2",
     "postcss": "^8.5.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
+import DOMPurify from 'dompurify';
 
 const isValidUrl = (url) => {
     try {
@@ -138,7 +139,7 @@ export default function ChatPage() {
             parts.push(
                 <a
                     key={`link-${match.index}`}
-                    href={isValidUrl(match[2]) ? match[2] : '#'}
+                    href={isValidUrl(match[2]) ? DOMPurify.sanitize(match[2]) : '#'}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 underline font-medium bg-blue-500/10 px-1 py-0.5 rounded transition-colors"


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/mslearn-mcp-chat/security/code-scanning/2](https://github.com/passadis/mslearn-mcp-chat/security/code-scanning/2)

To fix this issue, we should ensure that the `href` attribute is safe for use in the DOM. We will use a library like `dompurify` to sanitize the URL before rendering it in the `a` element. `dompurify` is a well-known library designed to mitigate XSS vulnerabilities by sanitizing untrusted HTML and URLs.

Steps to fix:
1. Install the `dompurify` library as a dependency.
2. Import `dompurify` in `pages/index.js`.
3. Use `DOMPurify.sanitize` to sanitize the `href` value before it is used in the `a` element.
4. Ensure that the rest of the code functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
